### PR TITLE
#8 - Allows filtering yoast_meta

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -7,7 +7,7 @@ add_action( 'plugins_loaded', 'WPAPIYoast_init' );
  * Description: Adds Yoast fields to page and post metadata to WP REST API responses
  * Author: Niels Garve, Pablo Postigo, Tedy Warsitha, Charlie Francis
  * Author URI: https://github.com/niels-garve
- * Version: 1.4.1
+ * Version: 1.4.2
  * Plugin URI: https://github.com/niels-garve/yoast-to-rest-api
  */
 class Yoast_To_REST_API {
@@ -132,6 +132,17 @@ class Yoast_To_REST_API {
 			'yoast_wpseo_canonical' => $wpseo_frontend->canonical( false ),
 		);
 
+		/**
+		 * Filter the returned yoast meta.
+		 *
+		 * @since 1.4.2
+		 * @param array $yoast_meta Array of metadata to return from Yoast.
+		 * @param \WP_Post $p The current post object.
+		 * @param \WP_REST_Request $request The REST request.
+		 * @return array $yoast_meta Filtered meta array.
+		 */
+		$yoast_meta = apply_filters( 'wpseo_to_api_yoast_meta', $yoast_meta, $p, $request );
+
 		wp_reset_query();
 
 		return (array) $yoast_meta;
@@ -145,6 +156,15 @@ class Yoast_To_REST_API {
 			'yoast_wpseo_title'    => $wpseo_frontend->get_taxonomy_title(),
 			'yoast_wpseo_metadesc' => $wpseo_frontend->metadesc( false ),
 		);
+
+		/**
+		 * Filter the returned yoast meta for a taxonomy.
+		 *
+		 * @since 1.4.2
+		 * @param array $yoast_meta Array of metadata to return from Yoast.
+		 * @return array $yoast_meta Filtered meta array.
+		 */
+		$yoast_meta = apply_filters( 'wpseo_to_api_yoast_taxonomy_meta', $yoast_meta );
 
 		return (array) $yoast_meta;
 	}


### PR DESCRIPTION
With the ability to filter the $yoast_meta array, developers can add additional Yoast information to their API requests.