### PR TITLE
Feature/expose new social meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,25 @@ Currently fetching:
 - `yoast_wpseo_title`
 - `yoast_wpseo_metadesc`
 - `yoast_wpseo_canonical`
+- `yoast_wpseo_facebook_title` aka `yoast_wpseo_opengraph-title`
+- `yoast_wpseo_facebook_description` aka `yoast_wpseo_opengraph-description`
+- `yoast_wpseo_facebook_type`
+- `yoast_wpseo_facebook_image` aka `yoast_wpseo_opengraph-image`
+- `yoast_wpseo_twitter_title`
+- `yoast_wpseo_twitter_description`
+- `yoast_wpseo_twitter_image`
+- `yoast_wpseo_social_url`
+- `yoast_wpseo_website_name`
+- `yoast_wpseo_company_or_person`
+- `yoast_wpseo_person_name`
+- `yoast_wpseo_company_name`
+- `yoast_wpseo_company_logo`
+- `yoast_wpseo_website_name`
+- `yoast_wpseo_social_defaults`
 
 Currently updating:
 
 - `yoast_wpseo_focuskw`
-- `yoast_wpseo_title`
-- `yoast_wpseo_metadesc`
 - `yoast_wpseo_linkdex`
 - `yoast_wpseo_metakeywords`
 - `yoast_wpseo_meta-robots-noindex`
@@ -39,11 +52,25 @@ Currently updating:
 - `yoast_wpseo_meta-robots-adv`
 - `yoast_wpseo_canonical`
 - `yoast_wpseo_redirect`
-- `yoast_wpseo_opengraph-title`
-- `yoast_wpseo_opengraph-description`
-- `yoast_wpseo_opengraph-image`
-- `yoast_wpseo_twitter-title`
-- `yoast_wpseo_twitter-description`
-- `yoast_wpseo_twitter-image`
+
+`yoast_wpseo_defaults` includes the following:
+- `facebook_site`
+- `instagram_url`
+- `linkedin_url`
+- `myspace_url`
+- `og_default_image`
+- `og_frontpage_title`
+- `og_frontpage_desc`
+- `og_frontpage_image`
+- `opengraph`
+- `pinterest_url`
+- `pinterestverify`
+- `plus-publisher`
+- `twitter`
+- `twitter_site`,
+- `twitter_card_type`
+- `youtube_url`
+- `google_plus_url`
+- `fbadminapp`
 
 Thanks to Pablo Postigo, Tedy Warsitha and Charlie Francis for amazing contributions!

--- a/plugin.php
+++ b/plugin.php
@@ -198,11 +198,7 @@ class Yoast_To_REST_API {
 	}
 
 	function wp_api_encode_yoast_category( $category ) {
-		query_posts(
-			array(
-				'cat' => $category['id'],
-			)
-		);
+		query_posts( array( 'cat' => $category['id'] ) );
 
 		the_post();
 
@@ -214,11 +210,7 @@ class Yoast_To_REST_API {
 	}
 
 	function wp_api_encode_yoast_tag( $tag ) {
-		query_posts(
-			array(
-				'tag_id' => $tag['id'],
-			)
-		);
+		query_posts( array( 'tag_id' => $tag['id'] ) );
 
 		the_post();
 

--- a/plugin.php
+++ b/plugin.php
@@ -147,7 +147,6 @@ class Yoast_To_REST_API {
 			'yoast_wpseo_twitter_description'  => get_post_meta( $p['id'], '_yoast_wpseo_twitter-description', true ),
 			'yoast_wpseo_twitter_image'        => get_post_meta( $p['id'], '_yoast_wpseo_twitter-image', true ),
 			'yoast_wpseo_social_url'           => get_permalink( $p['id'] ) ?? '',
-			'yoast_wpseo_website_name'         => $yoast_titles['website_name'] ?? '',
 			'yoast_wpseo_company_or_person'    => $yoast_titles['company_or_person'] ?? '',
 			'yoast_wpseo_person_name'          => $yoast_titles['person_name'] ?? '',
 			'yoast_wpseo_company_name'         => $yoast_titles['company_name'] ?? '',

--- a/plugin.php
+++ b/plugin.php
@@ -139,24 +139,24 @@ class Yoast_To_REST_API {
 		$yoast_titles = get_option( 'wpseo_titles' );
 
 		$yoast_meta = array(
-			'yoast_wpseo_title'                => $wpseo_frontend->get_content_title(),
-			'yoast_wpseo_metadesc'             => $wpseo_frontend->metadesc( false ),
-			'yoast_wpseo_canonical'            => $wpseo_frontend->canonical( false ),
+			'yoast_wpseo_title'                => $wpseo_frontend->get_content_title() ?? '',
+			'yoast_wpseo_metadesc'             => $wpseo_frontend->metadesc( false ) ?? '',
+			'yoast_wpseo_canonical'            => $wpseo_frontend->canonical( false ) ?? '',
 			'yoast_wpseo_facebook_title'       => get_post_meta( $p['id'], '_yoast_wpseo_opengraph-title', true ),
 			'yoast_wpseo_facebook_description' => get_post_meta( $p['id'], '_yoast_wpseo_opengraph-description', true ),
-			'yoast_wpseo_facebook_type'        => $p['type'],
+			'yoast_wpseo_facebook_type'        => $p['type'] ?? '',
 			'yoast_wpseo_facebook_image'       => get_post_meta( $p['id'], '_yoast_wpseo_opengraph-image', true ),
 			'yoast_wpseo_twitter_title'        => get_post_meta( $p['id'], '_yoast_wpseo_twitter-title', true ),
 			'yoast_wpseo_twitter_description'  => get_post_meta( $p['id'], '_yoast_wpseo_twitter-description', true ),
 			'yoast_wpseo_twitter_image'        => get_post_meta( $p['id'], '_yoast_wpseo_twitter-image', true ),
-			'yoast_wpseo_social_url'           => get_permalink( $p['id'] ),
-			'yoast_wpseo_website_name'         => $yoast_titles['website_name'],
-			'yoast_wpseo_company_or_person'    => $yoast_titles['company_or_person'],
-			'yoast_wpseo_person_name'          => $yoast_titles['person_name'],
-			'yoast_wpseo_company_name'         => $yoast_titles['company_name'],
-			'yoast_wpseo_company_logo'         => $yoast_titles['company_logo'],
-			'yoast_wpseo_website_name'         => $yoast_titles['website_name'],
-			'yoast_wpseo_social_defaults'      => get_option( 'wpseo_social' ),
+			'yoast_wpseo_social_url'           => get_permalink( $p['id'] ) ?? '',
+			'yoast_wpseo_website_name'         => $yoast_titles['website_name'] ?? '',
+			'yoast_wpseo_company_or_person'    => $yoast_titles['company_or_person'] ?? '',
+			'yoast_wpseo_person_name'          => $yoast_titles['person_name'] ?? '',
+			'yoast_wpseo_company_name'         => $yoast_titles['company_name'] ?? '',
+			'yoast_wpseo_company_logo'         => $yoast_titles['company_logo'] ?? '',
+			'yoast_wpseo_website_name'         => $yoast_titles['website_name'] ?? '',
+			'yoast_wpseo_social_defaults'      => get_option( 'wpseo_social' ) ?? '',
 		);
 
 		/**
@@ -180,9 +180,9 @@ class Yoast_To_REST_API {
 		$wpseo_frontend->reset();
 
 		$yoast_meta = array(
-			'yoast_wpseo_title'    => $wpseo_frontend->get_taxonomy_title(),
-			'yoast_wpseo_metadesc' => $wpseo_frontend->metadesc( false ),
-			'yoast_wpseo_defaults' => get_option( 'wpseo_social' ),
+			'yoast_wpseo_title'           => $wpseo_frontend->get_taxonomy_title(),
+			'yoast_wpseo_metadesc'        => $wpseo_frontend->metadesc( false ),
+			'yoast_wpseo_social_defaults' => get_option( 'wpseo_social' ) ?? '',
 		);
 
 		/**

--- a/plugin.php
+++ b/plugin.php
@@ -153,7 +153,7 @@ class Yoast_To_REST_API {
 			'yoast_wpseo_company_name'         => $yoast_titles['company_name'] ?? '',
 			'yoast_wpseo_company_logo'         => $yoast_titles['company_logo'] ?? '',
 			'yoast_wpseo_website_name'         => $yoast_titles['website_name'] ?? '',
-			'yoast_wpseo_social_defaults'      => get_option( 'wpseo_social' ) ?? '',
+			'yoast_wpseo_social_defaults'      => get_option( 'wpseo_social' ),
 		);
 
 		/**
@@ -179,7 +179,7 @@ class Yoast_To_REST_API {
 		$yoast_meta = array(
 			'yoast_wpseo_title'           => $wpseo_frontend->get_taxonomy_title(),
 			'yoast_wpseo_metadesc'        => $wpseo_frontend->metadesc( false ),
-			'yoast_wpseo_social_defaults' => get_option( 'wpseo_social' ) ?? '',
+			'yoast_wpseo_social_defaults' => get_option( 'wpseo_social' ),
 		);
 
 		/**

--- a/plugin.php
+++ b/plugin.php
@@ -1,7 +1,4 @@
-<?php
-
-add_action( 'plugins_loaded', 'WPAPIYoast_init' );
-
+<?php // @codingStandardsIgnoreStart
 /**
  * Plugin Name: Yoast to REST API
  * Description: Adds Yoast fields to page and post metadata to WP REST API responses
@@ -238,3 +235,5 @@ function wpseo_not_loaded() {
 		__( '<b>Yoast to REST API</b> plugin not working because <b>Yoast SEO</b> plugin is not active.' )
 	);
 }
+
+add_action( 'plugins_loaded', 'WPAPIYoast_init' );

--- a/plugin.php
+++ b/plugin.php
@@ -28,7 +28,7 @@ class Yoast_To_REST_API {
 		'yoast_wpseo_opengraph-image',
 		'yoast_wpseo_twitter-title',
 		'yoast_wpseo_twitter-description',
-		'yoast_wpseo_twitter-image'
+		'yoast_wpseo_twitter-image',
 	);
 
 	function __construct() {
@@ -37,7 +37,8 @@ class Yoast_To_REST_API {
 
 	function add_yoast_data() {
 		// Posts
-		register_rest_field( 'post',
+		register_rest_field(
+			'post',
 			'yoast_meta',
 			array(
 				'get_callback'    => array( $this, 'wp_api_encode_yoast' ),
@@ -47,7 +48,8 @@ class Yoast_To_REST_API {
 		);
 
 		// Pages
-		register_rest_field( 'page',
+		register_rest_field(
+			'page',
 			'yoast_meta',
 			array(
 				'get_callback'    => array( $this, 'wp_api_encode_yoast' ),
@@ -57,7 +59,8 @@ class Yoast_To_REST_API {
 		);
 
 		// Category
-		register_rest_field( 'category',
+		register_rest_field(
+			'category',
 			'yoast_meta',
 			array(
 				'get_callback'    => array( $this, 'wp_api_encode_yoast_category' ),
@@ -67,7 +70,8 @@ class Yoast_To_REST_API {
 		);
 
 		// Tag
-		register_rest_field( 'tag',
+		register_rest_field(
+			'tag',
 			'yoast_meta',
 			array(
 				'get_callback'    => array( $this, 'wp_api_encode_yoast_tag' ),
@@ -77,13 +81,16 @@ class Yoast_To_REST_API {
 		);
 
 		// Public custom post types
-		$types = get_post_types( array(
-			'public'   => true,
-			'_builtin' => false
-		) );
+		$types = get_post_types(
+			array(
+				'public'   => true,
+				'_builtin' => false,
+			)
+		);
 
 		foreach ( $types as $key => $type ) {
-			register_rest_field( $type,
+			register_rest_field(
+				$type,
 				'yoast_meta',
 				array(
 					'get_callback'    => array( $this, 'wp_api_encode_yoast' ),
@@ -119,17 +126,37 @@ class Yoast_To_REST_API {
 		$wpseo_frontend = WPSEO_Frontend_To_REST_API::get_instance();
 		$wpseo_frontend->reset();
 
-		query_posts( array(
-			'p'         => $p['id'], // ID of a page, post, or custom type
-			'post_type' => 'any'
-		) );
+		query_posts(
+			array(
+				'p'         => $p['id'], // ID of a page, post, or custom type
+				'post_type' => 'any',
+			)
+		);
 
 		the_post();
 
+		// title options — defaults.
+		$yoast_titles = get_option( 'wpseo_titles' );
+
 		$yoast_meta = array(
-			'yoast_wpseo_title'     => $wpseo_frontend->get_content_title(),
-			'yoast_wpseo_metadesc'  => $wpseo_frontend->metadesc( false ),
-			'yoast_wpseo_canonical' => $wpseo_frontend->canonical( false ),
+			'yoast_wpseo_title'                => $wpseo_frontend->get_content_title(),
+			'yoast_wpseo_metadesc'             => $wpseo_frontend->metadesc( false ),
+			'yoast_wpseo_canonical'            => $wpseo_frontend->canonical( false ),
+			'yoast_wpseo_facebook_title'       => get_post_meta( $p['id'], '_yoast_wpseo_opengraph-title', true ),
+			'yoast_wpseo_facebook_description' => get_post_meta( $p['id'], '_yoast_wpseo_opengraph-description', true ),
+			'yoast_wpseo_facebook_type'        => $p['type'],
+			'yoast_wpseo_facebook_image'       => get_post_meta( $p['id'], '_yoast_wpseo_opengraph-image', true ),
+			'yoast_wpseo_twitter_title'        => get_post_meta( $p['id'], '_yoast_wpseo_twitter-title', true ),
+			'yoast_wpseo_twitter_description'  => get_post_meta( $p['id'], '_yoast_wpseo_twitter-description', true ),
+			'yoast_wpseo_twitter_image'        => get_post_meta( $p['id'], '_yoast_wpseo_twitter-image', true ),
+			'yoast_wpseo_social_url'           => get_permalink( $p['id'] ),
+			'yoast_wpseo_website_name'         => $yoast_titles['website_name'],
+			'yoast_wpseo_company_or_person'    => $yoast_titles['company_or_person'],
+			'yoast_wpseo_person_name'          => $yoast_titles['person_name'],
+			'yoast_wpseo_company_name'         => $yoast_titles['company_name'],
+			'yoast_wpseo_company_logo'         => $yoast_titles['company_logo'],
+			'yoast_wpseo_website_name'         => $yoast_titles['website_name'],
+			'yoast_wpseo_social_defaults'      => get_option( 'wpseo_social' ),
 		);
 
 		/**
@@ -155,6 +182,7 @@ class Yoast_To_REST_API {
 		$yoast_meta = array(
 			'yoast_wpseo_title'    => $wpseo_frontend->get_taxonomy_title(),
 			'yoast_wpseo_metadesc' => $wpseo_frontend->metadesc( false ),
+			'yoast_wpseo_defaults' => get_option( 'wpseo_social' ),
 		);
 
 		/**
@@ -170,9 +198,11 @@ class Yoast_To_REST_API {
 	}
 
 	function wp_api_encode_yoast_category( $category ) {
-		query_posts( array(
-			'cat' => $category['id'],
-		) );
+		query_posts(
+			array(
+				'cat' => $category['id'],
+			)
+		);
 
 		the_post();
 
@@ -184,9 +214,11 @@ class Yoast_To_REST_API {
 	}
 
 	function wp_api_encode_yoast_tag( $tag ) {
-		query_posts( array(
-			'tag_id' => $tag['id'],
-		) );
+		query_posts(
+			array(
+				'tag_id' => $tag['id'],
+			)
+		);
 
 		the_post();
 


### PR DESCRIPTION
This PR exposes additional data into the REST endpoint.  Those data points are:

- `yoast_wpseo_facebook_title` aka `yoast_wpseo_opengraph-title`
- `yoast_wpseo_facebook_description` aka `yoast_wpseo_opengraph-description`
- `yoast_wpseo_facebook_type`
- `yoast_wpseo_facebook_image` aka `yoast_wpseo_opengraph-image`
- `yoast_wpseo_twitter_title`
- `yoast_wpseo_twitter_description`
- `yoast_wpseo_twitter_image`
- `yoast_wpseo_social_url`
- `yoast_wpseo_website_name`
- `yoast_wpseo_company_or_person`
- `yoast_wpseo_person_name`
- `yoast_wpseo_company_name`
- `yoast_wpseo_company_logo`
- `yoast_wpseo_website_name`
- `yoast_wpseo_social_defaults`

The defaults include the following:
- `facebook_site`
- `instagram_url`
- `linkedin_url`
- `myspace_url`
- `og_default_image`
- `og_frontpage_title`
- `og_frontpage_desc`
- `og_frontpage_image`
- `opengraph`
- `pinterest_url`
- `pinterestverify`
- `plus-publisher`
- `twitter`
- `twitter_site`,
- `twitter_card_type`
- `youtube_url`
- `google_plus_url`
- `fbadminapp`

This is on top of the title, meta desc, and the canonical URL.

I've also updated the readme to reflect this change.